### PR TITLE
Fixed useDoubles Option of Precompiler

### DIFF
--- a/codegen-cpp/src/main/java/de/gaalop/cpp/CppVisitor.java
+++ b/codegen-cpp/src/main/java/de/gaalop/cpp/CppVisitor.java
@@ -216,8 +216,6 @@ public class CppVisitor extends DefaultCodeGeneratorVisitor {
     @Override
     public void visit(FloatConstant floatConstant) {
         code.append(Double.toString(floatConstant.getValue()));
-        if (variableType.equals("double"))
-            code.append('d');
     }
 
     @Override

--- a/gpc/src/main/java/de/gaalop/gpc/BlockTransformer.java
+++ b/gpc/src/main/java/de/gaalop/gpc/BlockTransformer.java
@@ -241,7 +241,7 @@ public class BlockTransformer {
         Set<CodeGeneratorPlugin> plugins = Plugins.getCodeGeneratorPlugins();
         for (CodeGeneratorPlugin plugin : plugins) {
             if (plugin.getClass().getName().equals(Main.codeGeneratorPlugin)) {
-                if(plugin instanceof de.gaalop.compressed.CompressedCodeGenerator && Main.useDoubles) {
+                if(plugin instanceof de.gaalop.compressed.Plugin && Main.useDoubles) {
                     ((de.gaalop.compressed.Plugin) plugin).useDouble = true;
                 }
                 


### PR DESCRIPTION
The option "--double" was not correctly passed to the CodeGenerator. Additionally the "d" suffix was removed for compatibility with msvc.