### PR TITLE
Better plugin discovery

### DIFF
--- a/distribution/src/main/resources/startupscripts/start.sh
+++ b/distribution/src/main/resources/startupscripts/start.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
-java -jar starter-1.0.0.jar $@
+
+here=$(realpath $(dirname $0))
+java -jar $here/starter-1.0.0.jar $@


### PR DESCRIPTION
Whilst I was trying to create an [aur](https://wiki.archlinux.org/title/AUR) package for gaalop, I stumbled over the fact that the plugin discovery process heavily depends on the current working directory.

This is very inconvenient for the end user - especially in the cli domain. Therefor, I have rewritten part of the Main class to try both the current working directory as well as the directory the `starter-1.0.0.jar` lives in.

